### PR TITLE
Add summarize option

### DIFF
--- a/.github/workflows/pr-multi-measure-summarize-job.yml
+++ b/.github/workflows/pr-multi-measure-summarize-job.yml
@@ -1,0 +1,48 @@
+name: PR Multi-Measurement Summarize Job Flow
+
+on:
+  pull_request:
+    branches:
+      - "**"
+
+# The results in these jobs contain multiple measures and some jobs have a
+# custom summarize parameter
+
+jobs:
+  setup:
+    name: Setup Tachometer Reporting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Initialize tachometer comment
+        uses: andrewiggins/tachometer-reporter-action@master
+        with:
+          initialize: true
+
+  bench_1:
+    name: First Bench Job
+    needs: [setup]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Report Tachometer Result
+        uses: andrewiggins/tachometer-reporter-action@master
+        with:
+          path: tests/results/multi-measure-results.json
+          report-id: multi-bench-1
+          pr-bench-name: local-framework
+          base-bench-name: base-framework
+
+  bench_2:
+    name: Second Bench Job
+    needs: [setup]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Report Other Tachometer Result
+        uses: andrewiggins/tachometer-reporter-action@master
+        with:
+          path: tests/results/multi-measure-names.json
+          report-id: multi-measure-names
+          pr-bench-name: local-framework
+          base-bench-name: base-framework
+          summarize: render, update

--- a/.github/workflows/pr-multi-measure-summarize-job.yml
+++ b/.github/workflows/pr-multi-measure-summarize-job.yml
@@ -25,12 +25,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Report Tachometer Result
-        uses: andrewiggins/tachometer-reporter-action@master
+        uses: andrewiggins/tachometer-reporter-action@summarize-option
         with:
           path: tests/results/multi-measure-results.json
           report-id: multi-bench-1
           pr-bench-name: local-framework
           base-bench-name: base-framework
+          summarize: duration
 
   bench_2:
     name: Second Bench Job
@@ -39,10 +40,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Report Other Tachometer Result
-        uses: andrewiggins/tachometer-reporter-action@master
+        uses: andrewiggins/tachometer-reporter-action@summarize-option
         with:
           path: tests/results/multi-measure-names.json
           report-id: multi-measure-names
-          pr-bench-name: local-framework
-          base-bench-name: base-framework
+          pr-bench-name: this-change
+          base-bench-name: tip-of-tree
           summarize: render, update

--- a/.github/workflows/pr-single.yml
+++ b/.github/workflows/pr-single.yml
@@ -24,3 +24,6 @@ jobs:
           path: tests/results/test-results.json
           pr-bench-name: local-framework
           base-bench-name: base-framework
+          summarize:
+            - test1
+            - test2

--- a/.github/workflows/pr-single.yml
+++ b/.github/workflows/pr-single.yml
@@ -24,6 +24,4 @@ jobs:
           path: tests/results/test-results.json
           pr-bench-name: local-framework
           base-bench-name: base-framework
-          summarize:
-            - test1
-            - test2
+          summarize: test1, test2

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -31,6 +31,20 @@
         "!**/dist/**",
         "!**/node_modules/**"
       ]
+    },
+    {
+      "type": "pwa-node",
+      "request": "launch",
+      "name": "buildReport Tests",
+      "skipFiles": ["<node_internals>/**"],
+      "program": "${workspaceFolder}/tests/buildReport.test.js",
+      "outFiles": [
+        "${workspaceFolder}/lib/**/*.js",
+        "${workspaceFolder}/src/**/*.js",
+        "${workspaceFolder}/tests/**/*.js",
+        "!**/dist/**",
+        "!**/node_modules/**"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -118,9 +118,9 @@ By default, if `pr-bench-name` or `base-bench-name` are not provided, then the
 first two benchmarks in the tachometer results will be compared.
 
 You can also define which measures are summarized in the summary section. Pass
-the names of the measure you want to summarize into the `summarize` option. It
+the names of the measures you want to summarize to the `summarize` option. It
 accepts the value `true` (the default) to summarize all measures, `false`
-meaning to summarize nothing from this run, or a comma separated string of
+meaning to summarize nothing from this run, or a string of comma separated
 measurement names (e.g. `measure1, measure2`) to include in the summary.
 
 ### In-progress benchmarks
@@ -183,14 +183,15 @@ Specify which measurements to include in the summary for this benchmark. Accepts
 the following values:
 
 <dl>
-  <dt><code>true</code></dt>
+  <dt><code>true</code> (default)</dt>
   <dd>Include all measurements from this run in the summary section</dd>
   <dt><code>false</code></dt>
   <dd>Summarize nothing from this run</dd>
   <dt>include string</dt>
   <dd>
 		Only include the listed measurements in the summary string.
-		Must be a comma-separated string (e.g. <code>summarize: measure1, measure2</code>)
+		Must be a string of comma-separated measurement names
+		(e.g. <code>summarize: measure1, measure2</code>)
   </dd>
 </dl>
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ the comment.
 By default, if `pr-bench-name` or `base-bench-name` are not provided, then the
 first two benchmarks in the tachometer results will be compared.
 
+You can also define which measures are summarized in the summary section. Pass
+the names of the measure you want to summarize into the `summarize` option. It
+accepts the value `true` (the default) to summarize all measures, `false`
+meaning to summarize nothing from this run, or a comma separated string of
+measurement names (e.g. `measure1, measure2`) to include in the summary.
+
 ### In-progress benchmarks
 
 ![Picture of a PR comment with icons indicating in progress benchmarks](./docs/in-progress-comment-with-results.png)
@@ -170,6 +176,23 @@ the comment by passing initialize: true. Then each other job that actually
 reports benchmark results must declare the "setup" job as a dependency in its
 "needs" array. See the [Multiple benchmark jobs](#multiple-benchmark-jobs) usage
 sample for an example.
+
+### summarize
+
+Specify which measurements to include in the summary for this benchmark. Accepts
+the following values:
+
+<dl>
+  <dt><code>true</code></dt>
+  <dd>Include all measurements from this run in the summary section</dd>
+  <dt><code>false</code></dt>
+  <dd>Summarize nothing from this run</dd>
+  <dt>include string</dt>
+  <dd>
+		Only include the listed measurements in the summary string.
+		Must be a comma-separated string (e.g. <code>summarize: measure1, measure2</code>)
+  </dd>
+</dl>
 
 #### default-open
 

--- a/action.yml
+++ b/action.yml
@@ -14,14 +14,18 @@ inputs:
   initialize:
     description: "Whether this action should initialize the comment to report results. Use this option with report-id. Useful if multiple jobs are sharing the same comment. Pass in 'true' if this job should always create the comment"
     require: false
+  summarize:
+    description: "Specify whether to summarize (true), don't summarize any measurements (false), or which measurements to summarize (list of measurement names)"
+    require: false
+    default: "true"
   default-open:
     description: "Whether to open this action's results table by default"
     required: false
     default: "false"
-  keep-old-results:
-    description: Whether to keep old results in the comment on re-runs
-    required: false
-    default: "false"
+  # keep-old-results:
+  #   description: Whether to keep old results in the comment on re-runs
+  #   required: false
+  #   default: "false"
   pr-bench-name:
     description: "The name of the benchmark/version in tachometer results (i.e. benchmark.name or benchmark.version) that represents the code produced by this PR"
     required: false

--- a/dist/util.js
+++ b/dist/util.js
@@ -14940,6 +14940,7 @@ const defaultInputs = {
 	initialize: null,
 	prBenchName: null,
 	baseBenchName: null,
+	summarize: true,
 	keepOldResults: false,
 	defaultOpen: false,
 };
@@ -15093,6 +15094,9 @@ function getInputs(logger) {
 	const defaultOpen = core.getInput("default-open", { required: false });
 	const prBenchName = core.getInput("pr-bench-name", { required: false });
 	const baseBenchName = core.getInput("base-bench-name", { required: false });
+	const summarize = core.getInput("summarize", { required: false });
+
+	console.log("summarize:", JSON.stringify(summarize));
 
 	/** @type {import('../global').Inputs} */
 	const inputs = {

--- a/src/actions/util.js
+++ b/src/actions/util.js
@@ -35,6 +35,9 @@ function getInputs(logger) {
 	const defaultOpen = core.getInput("default-open", { required: false });
 	const prBenchName = core.getInput("pr-bench-name", { required: false });
 	const baseBenchName = core.getInput("base-bench-name", { required: false });
+	const summarize = core.getInput("summarize", { required: false });
+
+	console.log("summarize:", JSON.stringify(summarize));
 
 	/** @type {import('../global').Inputs} */
 	const inputs = {

--- a/src/actions/util.js
+++ b/src/actions/util.js
@@ -37,8 +37,6 @@ function getInputs(logger) {
 	const baseBenchName = core.getInput("base-bench-name", { required: false });
 	const summarize = core.getInput("summarize", { required: false });
 
-	console.log("summarize:", JSON.stringify(summarize));
-
 	/** @type {import('../global').Inputs} */
 	const inputs = {
 		path: path ? path : null,
@@ -48,7 +46,18 @@ function getInputs(logger) {
 		defaultOpen: defaultOpen !== "false",
 		prBenchName: prBenchName ? prBenchName : null,
 		baseBenchName: baseBenchName ? baseBenchName : null,
+		summarize: true,
 	};
+
+	if (summarize == "true") {
+		inputs.summarize = true;
+	} else if (summarize == "false") {
+		inputs.summarize = [];
+	} else if (typeof summarize == "string") {
+		inputs.summarize = summarize.split(",").map((s) => s.trim());
+	} else {
+		inputs.summarize = true;
+	}
 
 	if (inputs.prBenchName != null && inputs.baseBenchName == null) {
 		logger.warn(

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -75,7 +75,7 @@ interface Inputs {
 	initialize?: boolean;
 	prBenchName?: string;
 	baseBenchName?: string;
-	summarize?: boolean | string[];
+	summarize?: true | string[];
 	keepOldResults?: boolean;
 	defaultOpen?: boolean;
 }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -74,7 +74,8 @@ interface Inputs {
 	reportId?: string;
 	initialize?: boolean;
 	prBenchName?: string;
-	baseBenchName: ?string;
+	baseBenchName?: string;
+	summarize?: boolean | string[];
 	keepOldResults?: boolean;
 	defaultOpen?: boolean;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ function pickArray(array, indexes) {
 /**
  * @param {import("./global").CommitInfo} commitInfo
  * @param {import('./global').ActionInfo} actionInfo
- * @param {Pick<import('./global').Inputs, 'prBenchName' | 'baseBenchName' | 'defaultOpen' | 'reportId'>} inputs
+ * @param {Pick<import('./global').Inputs, 'prBenchName' | 'baseBenchName' | 'defaultOpen' | 'reportId' | 'summarize'>} inputs
  * @param {import('./global').PatchedTachResults} tachResults
  * @param {boolean} [isRunning]
  * @returns {import('./global').Report}
@@ -123,25 +123,31 @@ function buildReport(
 
 	if (resultsByMeasurement) {
 		for (let [measurementId, benches] of resultsByMeasurement) {
-			// TODO: Need to adjust benches differences array to accommodate reduced
-			// comparisons to just benches of same measurement. Handcrafted test
-			// results file doesn't appropriately replicate this scenario
-			summaries.push({
-				measurementId,
-				measurement: benches[0].measurement,
-				summary: (
-					<Summary
-						reportId={reportId}
-						measurementId={measurementId}
-						title={title}
-						benchmarks={benches}
-						prBenchName={inputs.prBenchName}
-						baseBenchName={inputs.baseBenchName}
-						actionInfo={actionInfo}
-						isRunning={isRunning}
-					/>
-				),
-			});
+			const measurement = benches[0].measurement;
+			if (
+				inputs.summarize === true ||
+				inputs.summarize.includes(measurement.name ?? "")
+			) {
+				// TODO: Need to adjust benches differences array to accommodate reduced
+				// comparisons to just benches of same measurement. Handcrafted test
+				// results file doesn't appropriately replicate this scenario
+				summaries.push({
+					measurementId,
+					measurement,
+					summary: (
+						<Summary
+							reportId={reportId}
+							measurementId={measurementId}
+							title={title}
+							benchmarks={benches}
+							prBenchName={inputs.prBenchName}
+							baseBenchName={inputs.baseBenchName}
+							actionInfo={actionInfo}
+							isRunning={isRunning}
+						/>
+					),
+				});
+			}
 		}
 	} else if (isRunning) {
 		// We don't have results meaning we don't know what measurements this report

--- a/src/index.js
+++ b/src/index.js
@@ -191,6 +191,7 @@ const defaultInputs = {
 	initialize: null,
 	prBenchName: null,
 	baseBenchName: null,
+	summarize: true,
 	keepOldResults: false,
 	defaultOpen: false,
 };

--- a/tests/getCommentBody.test.js
+++ b/tests/getCommentBody.test.js
@@ -125,13 +125,13 @@ function invokeGetCommentBody({
 /**
  * @param {string} label
  * @param {import('node-html-parser').HTMLElement} body
- * @param {{ isRunning?: boolean; hasResults?: boolean; }} [options]
+ * @param {{ isRunning?: boolean; hasResults?: boolean; summarize?: boolean }} [options]
  * @param {{ reportId?: string; measurementId?: string; }} [ids]
  */
 function assertUIState(
 	label,
 	body,
-	{ isRunning = false, hasResults = true } = {},
+	{ isRunning = false, hasResults = true, summarize = true } = {},
 	{ reportId = testReportId, measurementId = defaultMeasureId } = {}
 ) {
 	let summaryId = getSummaryId({ reportId, measurementId });
@@ -147,13 +147,16 @@ function assertUIState(
 	const msg = (message) => `${label}: ${message}`;
 
 	if (isRunning) {
-		assert.ok(summaryStatus, msg(`Summary running status link should exist`));
+		if (summarize) {
+			assert.ok(summaryStatus, msg(`Summary running status link should exist`));
+			let summaryText = summaryStatus?.text.includes("⏱");
+			assert.ok(summaryText, msg(`Summary running status link has text`));
+		} else {
+			assert.not.ok(summaryStatus, msg(`summary status link should not exist`));
+		}
+
 		assert.ok(resultStatus, msg(`Result running link should exist`));
-
-		let summaryText = summaryStatus?.text.includes("⏱");
 		let resultText = resultStatus?.text.includes("⏱");
-
-		assert.ok(summaryText, msg(`Summary running status link has text`));
 		assert.ok(resultText, msg(`Result running status link has text`));
 	} else {
 		assert.not.ok(summaryStatus, msg(`summary status link should not exist`));
@@ -161,7 +164,12 @@ function assertUIState(
 	}
 
 	if (hasResults) {
-		assert.ok(summaryData, msg(`summary results should exist`));
+		if (summarize) {
+			assert.ok(summaryData, msg(`summary results should exist`));
+		} else {
+			assert.not.ok(summaryData, msg(`summary results should not exist`));
+		}
+
 		assert.ok(resultData, msg(`result data should exist`));
 	} else {
 		assert.not.ok(summaryData, msg(`summary results should not exist`));
@@ -1688,6 +1696,56 @@ multiMeasure("Multi-measures without name fields", async () => {
 			`${title} has expected title`
 		);
 	}
+});
+
+multiMeasure("Multi-measures with summarize option", async () => {
+	const resultPath = testRoot("results/multi-measure-names.json");
+	const results = JSON.parse(await readFile(resultPath, "utf8"));
+	const reportId = "multi-measure-names";
+
+	const multiMeasureIds = [
+		"Bq0B3-8_UWt48DqpmNB3lNnwTd4",
+		"gN4D636F9Ua7c6W5IuuBZhQaUoU",
+		"MBkGEFvQqNyyN0MCAmJK9BTIAxU",
+	];
+
+	/** @type {Partial<import('../src/global').Inputs>} */
+	const inputs = {
+		reportId,
+		baseBenchName: "tip-of-tree",
+		prBenchName: "this-change",
+		summarize: ["update", "nop-update"],
+	};
+	const report = invokeBuildReport({ results, inputs });
+	const body = parse(invokeGetCommentBody({ report, inputs }));
+
+	assertUIState(
+		"No default measures",
+		body,
+		{ isRunning: false, hasResults: false },
+		{ reportId, measurementId: defaultMeasureId }
+	);
+
+	assertUIState(
+		"Measure 1 results",
+		body,
+		{ isRunning: false, hasResults: true, summarize: false },
+		{ reportId, measurementId: multiMeasureIds[0] }
+	);
+
+	assertUIState(
+		"Measure 2 results",
+		body,
+		{ isRunning: false, hasResults: true },
+		{ reportId, measurementId: multiMeasureIds[1] }
+	);
+
+	assertUIState(
+		"Measure 3 results",
+		body,
+		{ isRunning: false, hasResults: true },
+		{ reportId, measurementId: multiMeasureIds[2] }
+	);
 });
 
 //#endregion

--- a/tests/invokeBuildReport.js
+++ b/tests/invokeBuildReport.js
@@ -11,6 +11,7 @@ const { buildReport } = require("../lib/index");
  * @property {import('../src/global').TachResults} [results]
  * @property {boolean} [isRunning]
  * @param {BuildReportParams} params
+ * @returns {import('../src/global').Report}
  */
 function invokeBuildReport({
 	commit = fakeCommit,

--- a/tests/mocks/actions.js
+++ b/tests/mocks/actions.js
@@ -8,6 +8,7 @@ const defaultInputs = Object.freeze({
 	reportId: null,
 	prBenchName,
 	baseBenchName,
+	summarize: true,
 	defaultOpen: false,
 	keepOldResults: false,
 });


### PR DESCRIPTION
Allow the user to define which measurements from a benchmark should be summarized. `true` means include all measurements in the summary, `false` means include none of the measurements, and a string of comma-separated measurement names means only include the names of these measurements in the summary.

Closes #32